### PR TITLE
Updated keyboard.py: Could not import keyboard

### DIFF
--- a/keyboard/keyboard.py
+++ b/keyboard/keyboard.py
@@ -7,7 +7,7 @@ import platform
 if platform.system() == 'Windows':
     import keyboard.winkeyboard as os_keyboard
 else:
-    import keyboard.nixkeyboard as os_keyboard
+    from. import nixkeyboard as os_keyboard
 
 from .keyboard_event import KeyboardEvent, KEY_DOWN, KEY_UP, normalize_name    
 from .generic import GenericListener


### PR DESCRIPTION
Changed nixkeyboard import into an explicit relative import. From PEP-8, this type of import is encouraged in both Python 2.7.x and 3.x (https://www.python.org/dev/peps/pep-0008/#imports). I have not tested this in Windows, as I don't use this OS, and so I have not proposed changes for Windows. Python 3.5 had no difficulty with the original code in nix. In Python 2.7.11, the following occurs:
 
In [1]: import keyboard
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-3be1cee3c41f> in <module>()
----> 1 import keyboard

.../env/py27/lib/python2.7/site-packages/keyboard/__init__.py in <module>()
----> 1 from .keyboard import *

.../env/py27/lib/python2.7/site-packages/keyboard/keyboard.py in <module>()
      8     import keyboard.winkeyboard as os_keyboard
      9 else:
---> 10     import keyboard.nixkeyboard as os_keyboard
     11 
     12 from .keyboard_event import KeyboardEvent, KEY_DOWN, KEY_UP, normalize_name

ImportError: No module named nix keyboard