### PR TITLE
fix for mouse support in linux mint virtualbox guest

### DIFF
--- a/keyboard/_nixcommon.py
+++ b/keyboard/_nixcommon.py
@@ -146,13 +146,15 @@ def aggregate_devices(type_name):
     # We don't aggregate devices from different sources to avoid
     # duplicates.
 
-    devices_from_by_id = list(list_devices_from_by_id(type_name))
-    if devices_from_by_id:
-        return AggregatedEventDevice(devices_from_by_id, output=fake_device)
-
     devices_from_proc = list(list_devices_from_proc(type_name))
     if devices_from_proc:
         return AggregatedEventDevice(devices_from_proc, output=fake_device)
+
+    # breaks on mouse for virtualbox
+    # was getting /dev/input/by-id/usb-VirtualBox_USB_Tablet-event-mouse
+    devices_from_by_id = list(list_devices_from_by_id(type_name))
+    if devices_from_by_id:
+        return AggregatedEventDevice(devices_from_by_id, output=fake_device)
 
     # If no keyboards were found we can only use the fake device to send keys.
     return fake_device

--- a/keyboard/_nixmouse.py
+++ b/keyboard/_nixmouse.py
@@ -63,7 +63,7 @@ button_by_code = {
     BTN_EXTRA: X2,
 }
 code_by_button = {button: code for code, button in button_by_code.items()}
-    
+
 device = None
 def build_device():
     global device
@@ -76,7 +76,7 @@ def listen(queue):
     build_device()
 
     while True:
-        time, type, code, value, device = device.read_event()
+        time, type, code, value, device_id = device.read_event()
         if type == EV_SYN or type == EV_MSC:
             continue
 
@@ -93,11 +93,11 @@ def listen(queue):
             elif code in (REL_X, REL_Y):
                 x, y = get_position()
                 event = MoveEvent(x, y, time)
-        
+
         if event is None:
             # Unknown event type.
             continue
-            
+
         queue.put(event)
 
 def press(button=LEFT):
@@ -123,7 +123,7 @@ def wheel(delta=1):
     if delta < 0:
         delta += 2**32
     device.write_event(EV_REL, REL_WHEEL, delta)
-    
+
 
 if __name__ == '__main__':
     #listen(print)


### PR DESCRIPTION
- device was being overwritten in _nixmouse.py#listen() -> fixed to device_id

- switched order of sources to search for devices in aggregate_devices
  - linux mint in virtualbox kept finding /dev/input/by-id/usb-VirtualBox_USB_Tablet-event-mouse in device_from_by_id which didn't do anything