### PR TITLE
Remove type hints for winmouse ctype

### DIFF
--- a/keyboard/_winmouse.py
+++ b/keyboard/_winmouse.py
@@ -23,11 +23,11 @@ class MSLLHOOKSTRUCT(Structure):
 LowLevelMouseProc = CFUNCTYPE(c_int, WPARAM, LPARAM, POINTER(MSLLHOOKSTRUCT))
 
 SetWindowsHookEx = user32.SetWindowsHookExA
-SetWindowsHookEx.argtypes = [c_int, LowLevelMouseProc, c_int, c_int]
+#SetWindowsHookEx.argtypes = [c_int, LowLevelMouseProc, c_int, c_int]
 SetWindowsHookEx.restype = HHOOK
 
 CallNextHookEx = user32.CallNextHookEx
-CallNextHookEx.argtypes = [c_int , c_int, c_int, POINTER(MSLLHOOKSTRUCT)]
+#CallNextHookEx.argtypes = [c_int , c_int, c_int, POINTER(MSLLHOOKSTRUCT)]
 CallNextHookEx.restype = c_int
 
 UnhookWindowsHookEx = user32.UnhookWindowsHookEx


### PR DESCRIPTION
I don't understand enough to know why this works but it is the same thing that was done with _winkeyboard.py. Resolves issue https://github.com/boppreh/keyboard/issues/80