### PR TITLE
fix mac unknown non-unicode keyboard layout

### DIFF
--- a/keyboard/_darwinkeyboard.py
+++ b/keyboard/_darwinkeyboard.py
@@ -106,6 +106,8 @@ class KeyMap(object):
         Carbon.LMGetKbdType.restype = ctypes.c_uint32
         Carbon.TISCopyCurrentKeyboardInputSource.argtypes = []
         Carbon.TISCopyCurrentKeyboardInputSource.restype = ctypes.c_void_p
+        Carbon.TISCopyCurrentASCIICapableKeyboardLayoutInputSource.argtypes = []
+        Carbon.TISCopyCurrentASCIICapableKeyboardLayoutInputSource.restype = ctypes.c_void_p
         Carbon.TISGetInputSourceProperty.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
         Carbon.TISGetInputSourceProperty.restype = ctypes.c_void_p
         Carbon.UCKeyTranslate.argtypes = [ctypes.c_void_p,
@@ -123,6 +125,9 @@ class KeyMap(object):
         # Get keyboard layout
         klis = Carbon.TISCopyCurrentKeyboardInputSource()
         k_layout = Carbon.TISGetInputSourceProperty(klis, kTISPropertyUnicodeKeyLayoutData)
+        if k_layout is None:
+            klis = Carbon.TISCopyCurrentASCIICapableKeyboardLayoutInputSource()
+            k_layout = Carbon.TISGetInputSourceProperty(klis, kTISPropertyUnicodeKeyLayoutData)
         k_layout_size = Carbon.CFDataGetLength(k_layout)
         k_layout_buffer = ctypes.create_string_buffer(k_layout_size) # TODO - Verify this works instead of initializing with empty string
         Carbon.CFDataGetBytes(k_layout, CFRange(0, k_layout_size), ctypes.byref(k_layout_buffer))


### PR DESCRIPTION
When I use Chinese or Japanese keyboard layouts in Mac OS, `import keyboard` would cause the `segmentation fault`. I created a pull request on https://github.com/moses-palmer/pynput/pull/58, and the solution is also usable here. Reference issue: https://github.com/boppreh/keyboard/issues/108