### PR TITLE
Fix windows key registration on linux

### DIFF
--- a/keyboard/_nixkeyboard.py
+++ b/keyboard/_nixkeyboard.py
@@ -84,9 +84,15 @@ def build_tables():
     # dumpkeys consistently misreports the Windows key, sometimes
     # skipping it completely or reporting as 'alt. 125 = left win,
     # 126 = right win.
-    if (125, ()) not in to_name or to_name[(125, ())] == 'alt':
+    if (125, ()) not in to_name or to_name[(125, ())] == ['alt']:
+        to_name[(125, ())].clear()
+        if (125, ()) in from_name['alt']:
+            from_name['alt'].remove((125, ()))
         register_key((125, ()), 'windows')
-    if (126, ()) not in to_name or to_name[(126, ())] == 'alt':
+    if (126, ()) not in to_name or to_name[(126, ())] == ['alt']:
+        to_name[(126, ())].clear()
+        if (126, ()) in from_name['alt']:
+            from_name['alt'].remove((126, ()))
         register_key((126, ()), 'windows')
 
     # The menu key is usually skipped altogether, so we also add it manually.


### PR DESCRIPTION
If dumpkeys reports windows key as alt, we remove that mapping and register the key manually.