### PR TITLE
doc: Be clear that add_hotkey is not sufficient

### DIFF
--- a/keyboard/__init__.py
+++ b/keyboard/__init__.py
@@ -616,6 +616,9 @@ def add_hotkey(hotkey, callback, args=(), suppress=False, timeout=1, trigger_on_
     `remove_hotkey(hotkey)` or `remove_hotkey(handler)`.
     before the hotkey state is reset.
 
+    To loop on waiting for hotkeys, call `wait()` after all hotkeys are
+    registered.
+
     Note: hotkeys are activated when the last key is *pressed*, not released.
     Note: the callback is executed in a separate thread, asynchronously. For an
     example of how to use a callback synchronously, see `wait`.
@@ -632,6 +635,8 @@ def add_hotkey(hotkey, callback, args=(), suppress=False, timeout=1, trigger_on_
 
         add_hotkey('ctrl+q', quit)
         add_hotkey('ctrl+alt+enter, space', some_callback)
+
+        wait()
     """
     if args:
         callback = lambda callback=callback: callback(*args)


### PR DESCRIPTION
Clarify that you need to wait to keep the script active so it can listen
to hotkeys (it does not spawn a process in the background that will wait
for them).

The line "For an example of how to use a callback synchronously, see
`wait`." indicates that `wait` is an alternative to add_hotkey and a
helpful way to use it.

wait seems to be a better alternative to `while True: pass`.

I found it difficult to figure out how to write a script that just waits
for hotkeys, and this addition would have helped me.