### PR TITLE
readme.md Fix remap_hotkey example

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ Example:
 
 ```py
 
-remap('alt+w', 'ctrl+up')
+remap_hotkey('alt+w', 'ctrl+up')
 ```
 
 


### PR DESCRIPTION
The `remap_hotkey` example:
https://github.com/boppreh/keyboard#keyboardremap_hotkeysrc-dst-suppresstrue-trigger_on_releasefalse

wasn't updated when the function was renamed:
from: `remap`
to: `remap_hotkey`

In the commit:
Use hooks to implement key remappings
https://github.com/boppreh/keyboard/commit/3ebe48b126296afca3c2f6a2c3bbc455a00c8643#diff-78144a085fc983d74768166c57ad6c89L1019-R1023
(This link doesn't scroll to the target lines where the name change occurred, scroll down manually,
they are near the bottom of the page)