### PR TITLE
CFUNCTYPE --> WINFUNCTYPE to use stdcall for x86

### DIFF
--- a/keyboard/_winkeyboard.py
+++ b/keyboard/_winkeyboard.py
@@ -29,7 +29,7 @@ except NameError:
 # this would be simply #include "windows.h".
 
 import ctypes
-from ctypes import c_short, c_char, c_uint8, c_int32, c_int, c_uint, c_uint32, c_long, Structure, CFUNCTYPE, POINTER
+from ctypes import c_short, c_char, c_uint8, c_int32, c_int, c_uint, c_uint32, c_long, Structure, WINFUNCTYPE, POINTER
 from ctypes.wintypes import WORD, DWORD, BOOL, HHOOK, MSG, LPWSTR, WCHAR, WPARAM, LPARAM, LONG, HMODULE, LPCWSTR, HINSTANCE, HWND
 LPMSG = POINTER(MSG)
 ULONG_PTR = POINTER(DWORD)
@@ -89,7 +89,7 @@ class INPUT(ctypes.Structure):
     _fields_ = (('type', DWORD),
                 ('union', _INPUTunion))
 
-LowLevelKeyboardProc = CFUNCTYPE(c_int, WPARAM, LPARAM, POINTER(KBDLLHOOKSTRUCT))
+LowLevelKeyboardProc = WINFUNCTYPE(c_int, WPARAM, LPARAM, POINTER(KBDLLHOOKSTRUCT))
 
 SetWindowsHookEx = user32.SetWindowsHookExW
 SetWindowsHookEx.argtypes = [c_int, LowLevelKeyboardProc, HINSTANCE , DWORD]


### PR DESCRIPTION
Use WINFUNCTYPE to ensure stdcall convention on x86 (32-bit) systems. Only spot testet on Windows 7 x86 and Windows 10 x64.

This fixes boppreh/keyboard#377