### PR TITLE
fixes to add_abbreviation for linux

### DIFF
--- a/keyboard/__init__.py
+++ b/keyboard/__init__.py
@@ -1148,7 +1148,8 @@ def add_abbreviation(source_text, replacement_text, match_suffix=False, timeout=
     For more details see `add_word_listener`.
     """
     replacement = '\b'*(len(source_text)+1) + replacement_text
-    callback = lambda: write(replacement)
+    if _platform.system() == 'Linux': callback = lambda: write(replacement,delay=.001)
+    else: callback = lambda: write(replacement)
     return add_word_listener(source_text, callback, match_suffix=match_suffix, timeout=timeout)
 
 # Aliases.


### PR DESCRIPTION
Fixed strange behaviour on linux from the add_abbreviation funtion by adding a slight delay slight delay between characters