### PR TITLE
Fix issue #397: Event listener fails when keyboard is disconnected

### DIFF
--- a/keyboard/_nixcommon.py
+++ b/keyboard/_nixcommon.py
@@ -103,7 +103,8 @@ class AggregatedEventDevice(object):
         self.output = output or self.devices[0]
         def start_reading(device):
             while True:
-                self.event_queue.put(device.read_event())
+                if device.input_file.readable():
+                    self.event_queue.put(device.read_event())
         for device in self.devices:
             thread = Thread(target=start_reading, args=[device])
             thread.setDaemon(True)


### PR DESCRIPTION
Issue #397 

I encountered the issue in a *nix machine (Ubuntu 16.04).
The fix makes it so that we don't ready the input file when a keyboard is
disconnected by checking the 'readable()' method on the file pointer, in Ubuntu
when the keyboard is re-connected the 'readable()' method returns True and
everything works as usual.