### PR TITLE
Removed administrator check for macs.

### DIFF
--- a/keyboard/_darwinkeyboard.py
+++ b/keyboard/_darwinkeyboard.py
@@ -448,8 +448,6 @@ def name_from_scancode(scan_code):
     return key_controller.map_scan_code(scan_code)
 
 def listen(callback):
-    if not os.geteuid() == 0:
-        raise OSError("Error 13 - Must be run as administrator")
     KeyEventListener(callback).run()
 
 def type_unicode(character):


### PR DESCRIPTION
I tested it. It isn't needed. Enforcing administrator is actually worse for
people that have alternate keyboard layouts based on my testing. When you
enforce administrator, I think the library is assuming the administrator's
keyboard layout which is probably qwerty and I don't know how to or if it's
possible to change that to something else. But when you run the library under
the actual user, it uses that user's keyboard mapping (tested with dvorak).

Looking at the commit history, I'm guessing the check was there because someone copied the linux setup files to create the mac ones. But I don't actually know for sure.