### PR TITLE
add_hotkey remove hook() where set_index(0)

### DIFF
--- a/keyboard/__init__.py
+++ b/keyboard/__init__.py
@@ -768,7 +768,7 @@ def add_hotkey(hotkey, callback, args=(), suppress=False, timeout=1, trigger_on_
         return remove_
 
     state = _State()
-    state.remove_catch_misses = None
+    state.remove_catch_misses = lambda: None
     state.remove_last_step = None
     state.suppressed_events = []
     state.last_update = float('-inf')
@@ -802,6 +802,7 @@ def add_hotkey(hotkey, callback, args=(), suppress=False, timeout=1, trigger_on_
         if new_index == 0:
             # This is done for performance reasons, avoiding a global key hook
             # that is always on.
+            state.remove_catch_misses()
             state.remove_catch_misses = lambda: None
         elif new_index == 1:
             state.remove_catch_misses()


### PR DESCRIPTION
fix this:

```python
import keyboard

def hk(*args):
	print "hk", args
r = keyboard.add_hotkey("q, q", hk, suppress=True)

# press q, q somewhere

# type something then remove hotkey
raw_input()
keyboard.remove_hotkey(r)

# keep this script running
raw_input()

# press q somewhere
```

```
Traceback (most recent call last):
  File "C:\Python27\lib\site-packages\keyboard\_winkeyboard.py", line 544, in low_level_keyboard_handler
    should_continue = process_key(event_type, vk, scan_code, is_extended)
  File "C:\Python27\lib\site-packages\keyboard\_winkeyboard.py", line 530, in process_key
    return callback(KeyboardEvent(event_type=event_type, scan_code=scan_code or -vk, name=name, is_keypad=is_keypad))
  File "C:\Python27\lib\site-packages\keyboard\__init__.py", line 236, in direct_callback
    if not all(hook(event) for hook in self.blocking_hooks):
  File "C:\Python27\lib\site-packages\keyboard\__init__.py", line 236, in <genexpr>
    if not all(hook(event) for hook in self.blocking_hooks):
  File "C:\Python27\lib\site-packages\keyboard\__init__.py", line 690, in catch_misses
    state.remove_last_step()
  File "C:\Python27\lib\site-packages\keyboard\__init__.py", line 605, in remove
    container[scan_codes].remove(handler)
ValueError: list.remove(x): x not in list
```