### PR TITLE
Added checks to remove_word_listener to avoid KeyError

### DIFF
--- a/keyboard/__init__.py
+++ b/keyboard/__init__.py
@@ -1231,9 +1231,12 @@ def add_word_listener(word, callback, triggers=['space'], match_suffix=False, ti
     hooked = hook(handler)
     def remove():
         hooked()
-        del _word_listeners[word]
-        del _word_listeners[handler]
-        del _word_listeners[remove]
+        if word in _word_listeners:
+            del _word_listeners[word]
+        if handler in _word_listeners:
+            del _word_listeners[handler]
+        if remove in _word_listeners:
+            del _word_listeners[remove]
     _word_listeners[word] = _word_listeners[handler] = _word_listeners[remove] = remove
     # TODO: allow multiple word listeners and removing them correctly.
     return remove


### PR DESCRIPTION
Noticed while working on my own daemon using this that if I have multiple word listeners with the same word but different triggers, or other strange / peculiar cases where this would crop up - it either wouldn't remove them entirely or would produce key errors because it would try to remove something that was already removed by a previous call of remove_word_listener. Adding this never hurts and it also fixed the bug on my local install, so that it makes sure they're present before trying to delete.

Thanks for the awesome library by the way!