### PR TITLE
DOC: Update 'Known Limitations' for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ python -m keyboard < events.txt
 - Events generated under Windows don't report device id (`event.device == None`). [#21](https://github.com/boppreh/keyboard/issues/21)
 - Media keys on Linux may appear nameless (scan-code only) or not at all. [#20](https://github.com/boppreh/keyboard/issues/20)
 - Key suppression/blocking only available on Windows. [#22](https://github.com/boppreh/keyboard/issues/22)
-- To avoid depending on X, the Linux parts reads raw device files (`/dev/input/input*`) but this requires root.
+- To avoid depending on X, the Linux parts reads raw device files (`/dev/input/input*`) but this requires the user to be a member of the `input` group.
 - Other applications, such as some games, may register hooks that swallow all key events. In this case `keyboard` will be unable to report events.
 - This program makes no attempt to hide itself, so don't use it for keyloggers or online gaming bots. Be responsible.
 - SSH connections forward only the text typed, not keyboard events. Therefore if you connect to a server or Raspberry PI that is running `keyboard` via SSH, the server will not detect your key events.


### PR DESCRIPTION
If I understand the changes in 7f03a3d correctly, the README is no longer correct in stating that root is required to use the library.

This PR updates the README to state the need for the invoking user to be in the `input` group instead.