### PR TITLE
as _winkeyboard.py states in line 438, init should be called in __init__.py

### DIFF
--- a/keyboard/__init__.py
+++ b/keyboard/__init__.py
@@ -234,6 +234,8 @@ class _Event(_UninterruptibleEvent):
 import platform as _platform
 if _platform.system() == 'Windows':
     from. import _winkeyboard as _os_keyboard
+    _os_keyboard.init()
+    _time.sleep(0.1)
 elif _platform.system() == 'Linux':
     from. import _nixkeyboard as _os_keyboard
     _os_keyboard.init()


### PR DESCRIPTION
Solves issue https://github.com/boppreh/keyboard/issues/551

Without `_os_keyboard.init()` using `keyboard.send(int)` the first time does nothing because the dict `scan_code_to_vk` wasnt filled yet.

I couldn't trace why using `keyboard.send("a")` works tho