### PR TITLE
docs: Fix a few typos

### DIFF
--- a/keyboard/__init__.py
+++ b/keyboard/__init__.py
@@ -272,7 +272,7 @@ class _KeyboardListener(_GenericListener):
         #|
         #|             Type of event that triggered this modifier update.
         #|             |
-        #|             |         Type of key that triggered this modiier update.
+        #|             |         Type of key that triggered this modifier update.
         #|             |         |
         #|             |         |            Should we send a fake key press?
         #|             |         |            |

--- a/keyboard/_mouse_tests.py
+++ b/keyboard/_mouse_tests.py
@@ -58,7 +58,7 @@ class TestMouse(unittest.TestCase):
     def flush_events(self):
         self.wait_for_events_queue()
         events = list(self.events)
-        # Ugly, but requried to work in Python2. Python3 has list.clear
+        # Ugly, but required to work in Python2. Python3 has list.clear
         del self.events[:]
         return events
 

--- a/keyboard/mouse.py
+++ b/keyboard/mouse.py
@@ -75,7 +75,7 @@ def move(x, y, absolute=True, duration=0):
     y = int(y)
 
     # Requires an extra system call on Linux, but `move_relative` is measured
-    # in millimiters so we would lose precision.
+    # in millimeters so we would lose precision.
     position_x, position_y = get_position()
 
     if not absolute:
@@ -205,7 +205,7 @@ def play(events, speed_factor=1.0, include_clicks=True, include_moves=True, incl
     intervals. If speed_factor is <= 0 then the actions are replayed as fast
     as the OS allows. Pairs well with `record()`.
 
-    The parameters `include_*` define if events of that type should be inluded
+    The parameters `include_*` define if events of that type should be included
     in the replay or ignored.
     """
     last_time = None


### PR DESCRIPTION
There are small typos in:
- keyboard/__init__.py
- keyboard/_mouse_tests.py
- keyboard/mouse.py

Fixes:
- Should read `required` rather than `requried`.
- Should read `modifier` rather than `modiier`.
- Should read `millimeters` rather than `millimiters`.
- Should read `included` rather than `inluded`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md