### PR TITLE
Remove early initialization (Fix #563)

### DIFF
--- a/keyboard/__init__.py
+++ b/keyboard/__init__.py
@@ -234,12 +234,8 @@ class _Event(_UninterruptibleEvent):
 import platform as _platform
 if _platform.system() == 'Windows':
     from. import _winkeyboard as _os_keyboard
-    _os_keyboard.init()
-    _time.sleep(0.1)
 elif _platform.system() == 'Linux':
     from. import _nixkeyboard as _os_keyboard
-    _os_keyboard.init()
-    _time.sleep(0.1)
 elif _platform.system() == 'Darwin':
     from. import _darwinkeyboard as _os_keyboard
 else:

--- a/keyboard/__init__.py
+++ b/keyboard/__init__.py
@@ -237,7 +237,11 @@ if _platform.system() == 'Windows':
 elif _platform.system() == 'Linux':
     from. import _nixkeyboard as _os_keyboard
 elif _platform.system() == 'Darwin':
-    from. import _darwinkeyboard as _os_keyboard
+    try:
+        from. import _darwinkeyboard as _os_keyboard
+    except ImportError:
+        # This can happen during setup if pyobj wasn't already installed
+        pass
 else:
     raise OSError("Unsupported platform '{}'".format(_platform.system()))
 


### PR DESCRIPTION
Don't initialize the keyboard by simply importing the module. This is often too soon. And runs when installing (because `setup.py` imports `keyboard`).

The keyboards are initialized later anyway though `start_if_necessary`

Fixes #563