### PR TITLE
Fix write work with delay

### DIFF
--- a/keyboard/__init__.py
+++ b/keyboard/__init__.py
@@ -973,6 +973,7 @@ def write(text, delay=0, restore_state_after=True, exact=None):
                 scan_code, modifiers = next(iter(entries))
             except (KeyError, ValueError, StopIteration):
                 _os_keyboard.type_unicode(letter)
+                if delay: _time.sleep(delay)
                 continue
             
             for modifier in modifiers:


### PR DESCRIPTION
Hello! I was working on my joke project using this library and found a strange bug. The delay parameter in the write function does not work correctly on Mac OS. We don't wait every delay time before every letter input, but wait a delay before every word input.

Issue: https://github.com/boppreh/keyboard/issues/582