### PR TITLE
Update _winkeyboard.py => load non qwerty special characters

### DIFF
--- a/keyboard/_winkeyboard.py
+++ b/keyboard/_winkeyboard.py
@@ -369,7 +369,7 @@ def get_event_names(scan_code, vk, is_extended, modifiers):
         # If your 6 and 7 keys are named "^6" and "^7", this is the reason.
         ToUnicode(vk, scan_code, keyboard_state, unicode_buffer, len(unicode_buffer), 0)
 
-    name_ret = GetKeyNameText(scan_code << 16 | is_extended << 24, name_buffer, 1024)
+    name_ret = GetKeyNameText(scan_code << 23 | is_extended << 24, name_buffer, 1024)
     if name_ret and name_buffer.value:
         yield name_buffer.value
 


### PR DESCRIPTION
Fix special characters for non QWERTY keyboards (23 bits instead of 16 bits loading from structure)