### PR TITLE
The keyboard devices are now getting automatically recognized and don't raise OSError when disconected

### DIFF
--- a/keyboard/_nixcommon.py
+++ b/keyboard/_nixcommon.py
@@ -101,23 +101,44 @@ class AggregatedEventDevice(object):
         self.event_queue = Queue()
         self.devices = devices
         self.output = output or self.devices[0]
-        def start_reading(device):
-            while True:
-                try:
-                    self.event_queue.put(device.read_event())
-                except OSError:
-                    break
-        for device in self.devices:
-            thread = Thread(target=start_reading, args=[device])
-            thread.daemon = True
-            thread.start()
 
+        for device in self.devices:
+            self.create_device_thread(device)
+        thread = Thread(target=self.check_for_new_devices)
+        thread.daemon = True
+        thread.start()
+
+    def check_for_new_devices(self):
+        while True:
+            devices_paths = [device.path for device in self.devices]
+            new_devices = [device.path for device in list_devices_from_proc("kbd")]
+
+            for new_device in new_devices:
+                if not(new_device in devices_paths):
+                    
+                    new_device_to_append = EventDevice(new_device)
+                    self.devices.append(new_device_to_append)
+                    self.create_device_thread(new_device_to_append)
     def read_event(self):
         return self.event_queue.get(block=True)
 
     def write_event(self, type, code, value):
         self.output.write_event(type, code, value)
 
+    def start_reading(self,device):
+        while True:
+            try:
+                self.event_queue.put(device.read_event())
+            except OSError:
+                if device in self.devices:
+                    self.devices.remove(device)
+                    
+                break
+
+    def create_device_thread(self, device):
+            thread = Thread(target=self.start_reading, args=[device])
+            thread.daemon = True
+            thread.start()
 import re
 from collections import namedtuple
 DeviceDescription = namedtuple('DeviceDescription', 'event_file is_mouse is_keyboard')

--- a/keyboard/_nixcommon.py
+++ b/keyboard/_nixcommon.py
@@ -103,7 +103,10 @@ class AggregatedEventDevice(object):
         self.output = output or self.devices[0]
         def start_reading(device):
             while True:
-                self.event_queue.put(device.read_event())
+                try:
+                    self.event_queue.put(device.read_event())
+                except OSError:
+                    break
         for device in self.devices:
             thread = Thread(target=start_reading, args=[device])
             thread.daemon = True

--- a/keyboard/_nixcommon.py
+++ b/keyboard/_nixcommon.py
@@ -3,6 +3,7 @@ import struct
 import os
 import atexit
 from time import time as now
+from time import sleep
 from threading import Thread
 from glob import glob
 try:
@@ -110,7 +111,9 @@ class AggregatedEventDevice(object):
 
     def check_for_new_devices(self):
         while True:
+            sleep(2)
             devices_paths = [device.path for device in self.devices]
+            
             new_devices = [device.path for device in list_devices_from_proc("kbd")]
 
             for new_device in new_devices:

--- a/keyboard/_nixkeyboard.py
+++ b/keyboard/_nixkeyboard.py
@@ -136,7 +136,7 @@ def listen(callback):
         try:
             time, type, code, value, device_id = device.read_event()
         except OSError:
-            #Try to reconect to the device
+            #Try to reconect to the device NOTE: if there are no keyboards connected after the disconection it will switch to a fake device
             device = None
             init()
             continue

--- a/keyboard/_nixkeyboard.py
+++ b/keyboard/_nixkeyboard.py
@@ -128,11 +128,18 @@ def init():
 pressed_modifiers = set()
 
 def listen(callback):
+    global device
     build_device()
     build_tables()
 
     while True:
-        time, type, code, value, device_id = device.read_event()
+        try:
+            time, type, code, value, device_id = device.read_event()
+        except OSError:
+            #Try to reconect to the device
+            device = None
+            init()
+            continue
         if type != EV_KEY:
             continue
 

--- a/keyboard/_nixkeyboard.py
+++ b/keyboard/_nixkeyboard.py
@@ -136,7 +136,7 @@ def listen(callback):
         try:
             time, type, code, value, device_id = device.read_event()
         except OSError:
-            #Try to reconect to the device NOTE: if there are no keyboards connected after the disconection it will switch to a fake device
+            
             device = None
             init()
             continue


### PR DESCRIPTION
When a  device is disconected on Linux based systems it causes an OSError and makes the program crash. Now the AggregatedEventDevice automatically creates a thread which checks for any new devices that are being added. It also recognises if a device has been removed and closes the thread that listened to that device's inputs. Issues:
#531
#639